### PR TITLE
feature is a devcontainers-extra now

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
   "features": {
-    "ghcr.io/devcontainers-contrib/features/jshint:2": {}
+     "ghcr.io/devcontainers-extra/features/jshint:2": {}
   }
 
   // Features to add to the dev container. More info: https://containers.dev/features.


### PR DESCRIPTION
jshint has been moved to -> https://github.com/devcontainers-extra 
The Gcr registry address has to be updated. 

